### PR TITLE
#20 [fix] 예외처리 구현 및 코딩컨벤션 검토

### DIFF
--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/CarrotServerApplication.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/CarrotServerApplication.java
@@ -8,8 +8,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @SpringBootApplication
 public class CarrotServerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(CarrotServerApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(CarrotServerApplication.class, args);
+    }
 
 }

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/common/ControllerExceptionAdvice.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/common/ControllerExceptionAdvice.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -24,7 +25,15 @@ public class ControllerExceptionAdvice {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected JsonResponse handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
         FieldError fieldError = Objects.requireNonNull(e.getFieldError());
-        return JsonResponse.error(ErrorType.REQUEST_HEADER_TOKEN_EXCEPTION, String.format("%s. (%s)", fieldError.getDefaultMessage(), fieldError.getField()));
+        return JsonResponse.error(ErrorType.VALIDATION_REQUEST_MISSING_EXCEPTION, String.format("%s. (%s)", fieldError.getDefaultMessage(), fieldError.getField()));
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    protected JsonResponse handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        String parameterName = e.getParameterName();
+        String errorMessage = String.format("'%s' 파라미터가 누락되었습니다.", parameterName);
+        return JsonResponse.error(ErrorType.VALIDATION_EXCEPTION, errorMessage);
     }
 
     /**
@@ -33,7 +42,7 @@ public class ControllerExceptionAdvice {
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
-    protected JsonResponse<Object> handleException(final Exception e) {
+    protected JsonResponse handleException(final Exception e) {
         return JsonResponse.error(ErrorType.INTERNAL_SERVER_ERROR);
     }
 

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/common/ControllerExceptionAdvice.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/common/ControllerExceptionAdvice.java
@@ -5,6 +5,7 @@ import cds.carrot.org.carrotServer.common.dto.JsonResponse;
 import cds.carrot.org.carrotServer.exception.ApiException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -25,7 +26,7 @@ public class ControllerExceptionAdvice {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected JsonResponse handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
         FieldError fieldError = Objects.requireNonNull(e.getFieldError());
-        return JsonResponse.error(ErrorType.VALIDATION_REQUEST_MISSING_EXCEPTION, String.format("%s. (%s)", fieldError.getDefaultMessage(), fieldError.getField()));
+        return JsonResponse.error(ErrorType.VALIDATION_REQUEST_MISSING_EXCEPTION, String.format("%s", fieldError.getDefaultMessage(), fieldError.getField()));
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/common/CustomInterceptor.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/common/CustomInterceptor.java
@@ -1,0 +1,26 @@
+package cds.carrot.org.carrotServer.common;
+
+import cds.carrot.org.carrotServer.common.dto.ErrorType;
+import cds.carrot.org.carrotServer.exception.BadRequestException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomInterceptor implements org.springframework.web.servlet.HandlerInterceptor {
+    private static final String AOS = "1";
+    private static final String IOS = "2";
+    private static final String AUTHORIZATION = "Authorization";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String userId = request.getHeader(AUTHORIZATION);
+        if (!(AOS.equals(userId) || IOS.equals(userId))) {
+            throw new BadRequestException(ErrorType.REQUEST_HEADER_TOKEN_EXCEPTION);
+        }
+        return true;
+    }
+
+}

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/common/WebMvcConfig.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/common/WebMvcConfig.java
@@ -1,0 +1,18 @@
+package cds.carrot.org.carrotServer.common;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Autowired
+    private CustomInterceptor headerInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(headerInterceptor);
+    }
+}

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/common/dto/ErrorType.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/common/dto/ErrorType.java
@@ -10,13 +10,18 @@ public enum ErrorType {
     /**
      * 400 BAD REQUEST
      */
+    VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청값이 입력되지 않았습니다."),
+
     REQUEST_HEADER_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 헤더 토큰 값입니다."),
-    REQUEST_SIZE_EXCEPTION(HttpStatus.BAD_REQUEST, "size가 음수입니다."),
+    REQUEST_SIZE_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 사이즈 값입니다. 사이즈는 음수일 수 없으며, 양의 정수이어야 합니다."),
 
     /**
      * 404 NOT FOUND
      */
     NOT_FOUND_USER_EXCEPTION(HttpStatus.NOT_FOUND, "해당 사용자의 리뷰를 찾을 수 없습니다."),
+
+    NOT_FOUND_POST_EXCEPTION(HttpStatus.NOT_FOUND, "해당 게시물을 찾을 수 없습니다."),
 
     /**
      * 500 INTERNAL SERVER ERROR

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/common/dto/JsonResponse.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/common/dto/JsonResponse.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 @JsonInclude(Include.NON_NULL)
 public class JsonResponse<T> {
 
-    private final int code;
+    private final int status;
     private final boolean success;
     private final String message;
     private T data;

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/common/dto/SuccessType.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/common/dto/SuccessType.java
@@ -9,16 +9,15 @@ public enum SuccessType {
     /**
      * 200 OK
      */
-    READ_REVIEW_LIST_SUCCESS(HttpStatus.OK, "알바 리스트 조회 성공"),
-    READ_BOARD_LIST_SUCCESS(HttpStatus.OK, "게시물 리스트 조회를 성공했습니다."),
-    READ_BOARD_RECOMMEND_SUCCESS(HttpStatus.OK, "추천 알바 리스트 조회를 성공했습니다."),
-    READ_BOARD_SUCCESS(HttpStatus.OK, "게시물 상세 조회를 성공했습니다."),
+    READ_REVIEW_LIST_SUCCESS(HttpStatus.OK, "후기 리스트 조회 성공"),
+    READ_BOARD_LIST_SUCCESS(HttpStatus.OK, "알바 리스트 조회 성공"),
+    READ_BOARD_RECOMMEND_SUCCESS(HttpStatus.OK, "추천 알바 리스트 조회 성공"),
+    READ_BOARD_SUCCESS(HttpStatus.OK, "알바 상세 정보 조회 성공"),
 
     /**
      * 201 CREATED
      */
-    SIGNUP_SUCCESS(HttpStatus.CREATED, "회원가입이 완료됐습니다."),
-    CREATE_PROFILE_SUCCESS(HttpStatus.CREATED, "프로필 생성을 완료됐습니다."),
+    CREATE_PROFILE_SUCCESS(HttpStatus.CREATED, "프로필 등록 성공"),
     ;
 
     private final HttpStatus httpStatus;

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/EmployerController.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/EmployerController.java
@@ -32,7 +32,7 @@ public class EmployerController {
         }
 
         if (size < 0) {
-            throw new BadRequestException(ErrorType.REQUEST_SIZE_EXCEPTION, ErrorType.REQUEST_SIZE_EXCEPTION.getMessage());
+            throw new BadRequestException(ErrorType.REQUEST_SIZE_EXCEPTION);
         }
 
         List<Review> reviews = employerService.getByUserId(userId);

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/EmployerController.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/EmployerController.java
@@ -4,13 +4,14 @@ import cds.carrot.org.carrotServer.common.dto.ErrorType;
 import cds.carrot.org.carrotServer.common.dto.JsonResponse;
 import cds.carrot.org.carrotServer.common.dto.SuccessType;
 import cds.carrot.org.carrotServer.controller.employer.dto.response.EmployerResponse;
+import cds.carrot.org.carrotServer.domain.employer.Review;
 import cds.carrot.org.carrotServer.exception.BadRequestException;
 import cds.carrot.org.carrotServer.service.employer.EmployerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,24 +20,13 @@ public class EmployerController {
 
     private final EmployerService employerService;
 
-    private static final String AOS = "1";
-    private static final String IOS = "2";
-    private static final String AUTHORIZATION = "Authorization";
-
     @GetMapping("/{userId}/reviews")
     @ResponseStatus(HttpStatus.FOUND)
-    public JsonResponse<EmployerResponse> getReviewList(HttpServletRequest request, @PathVariable Long userId, @RequestParam int size) {
-        String auth = request.getHeader(AUTHORIZATION);
-        if (!(AOS.equals(auth) || IOS.equals(auth))) {
-            throw new BadRequestException(ErrorType.REQUEST_HEADER_TOKEN_EXCEPTION, ErrorType.REQUEST_HEADER_TOKEN_EXCEPTION.getMessage());
-        }
-
+    public JsonResponse<EmployerResponse> getReviewList(@PathVariable Long userId, @RequestParam int size) {
         if (size < 0) {
             throw new BadRequestException(ErrorType.REQUEST_SIZE_EXCEPTION);
         }
-
         List<Review> reviews = employerService.getByUserId(userId);
-
         EmployerResponse response = EmployerResponse.of(employerService.getById(userId), reviews.subList(0, Math.min(size, reviews.size())));
         return JsonResponse.success(SuccessType.READ_REVIEW_LIST_SUCCESS, response);
     }

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/EmployerController.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/EmployerController.java
@@ -3,13 +3,10 @@ package cds.carrot.org.carrotServer.controller.employer;
 import cds.carrot.org.carrotServer.common.dto.ErrorType;
 import cds.carrot.org.carrotServer.common.dto.JsonResponse;
 import cds.carrot.org.carrotServer.common.dto.SuccessType;
-import cds.carrot.org.carrotServer.controller.employer.dto.response.EmployerResponseDto;
+import cds.carrot.org.carrotServer.controller.employer.dto.response.EmployerResponse;
 import cds.carrot.org.carrotServer.exception.BadRequestException;
 import cds.carrot.org.carrotServer.service.employer.EmployerService;
-import cds.carrot.org.carrotServer.service.employer.EmployerServiceImpl;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,7 +25,7 @@ public class EmployerController {
 
     @GetMapping("/{userId}/reviews")
     @ResponseStatus(HttpStatus.FOUND)
-    public JsonResponse<EmployerResponseDto> getReviewList(HttpServletRequest request, @PathVariable Long userId, @RequestParam int size) {
+    public JsonResponse<EmployerResponse> getReviewList(HttpServletRequest request, @PathVariable Long userId, @RequestParam int size) {
         String auth = request.getHeader(AUTHORIZATION);
         if (!(AOS.equals(auth) || IOS.equals(auth))) {
             throw new BadRequestException(ErrorType.REQUEST_HEADER_TOKEN_EXCEPTION, ErrorType.REQUEST_HEADER_TOKEN_EXCEPTION.getMessage());
@@ -38,7 +35,7 @@ public class EmployerController {
             throw new BadRequestException(ErrorType.REQUEST_SIZE_EXCEPTION, ErrorType.REQUEST_SIZE_EXCEPTION.getMessage());
         }
 
-        EmployerResponseDto responseDto = employerService.getUserWithReviews(userId, size);
+        EmployerResponse responseDto = employerService.getUserWithReviews(userId, size);
         return JsonResponse.success(SuccessType.READ_REVIEW_LIST_SUCCESS, responseDto);
     }
 

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/EmployerController.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/EmployerController.java
@@ -35,8 +35,10 @@ public class EmployerController {
             throw new BadRequestException(ErrorType.REQUEST_SIZE_EXCEPTION, ErrorType.REQUEST_SIZE_EXCEPTION.getMessage());
         }
 
-        EmployerResponse responseDto = employerService.getUserWithReviews(userId, size);
-        return JsonResponse.success(SuccessType.READ_REVIEW_LIST_SUCCESS, responseDto);
+        List<Review> reviews = employerService.getByUserId(userId);
+
+        EmployerResponse response = EmployerResponse.of(employerService.getById(userId), reviews.subList(0, Math.min(size, reviews.size())));
+        return JsonResponse.success(SuccessType.READ_REVIEW_LIST_SUCCESS, response);
     }
 
 }

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/EmployerController.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/EmployerController.java
@@ -9,6 +9,7 @@ import cds.carrot.org.carrotServer.exception.BadRequestException;
 import cds.carrot.org.carrotServer.service.employer.EmployerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,8 +23,10 @@ public class EmployerController {
 
     @GetMapping("/{userId}/reviews")
     @ResponseStatus(HttpStatus.FOUND)
-    public JsonResponse<EmployerResponse> getReviewList(@PathVariable Long userId, @RequestParam int size) {
-        if (size < 0) {
+    public JsonResponse<EmployerResponse> getReviewList(@PathVariable Long userId, @RequestParam(required = false) Integer size) {
+        if (ObjectUtils.isEmpty(size)) {
+            throw new BadRequestException(ErrorType.VALIDATION_REQUEST_MISSING_EXCEPTION);
+        } else if (size < 0) {
             throw new BadRequestException(ErrorType.REQUEST_SIZE_EXCEPTION);
         }
         List<Review> reviews = employerService.getByUserId(userId);

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/dto/response/EmployerResponse.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/dto/response/EmployerResponse.java
@@ -2,34 +2,23 @@ package cds.carrot.org.carrotServer.controller.employer.dto.response;
 
 import cds.carrot.org.carrotServer.domain.employer.Review;
 import cds.carrot.org.carrotServer.domain.employer.User;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @Builder
-@NoArgsConstructor
+@AllArgsConstructor
 public class EmployerResponse {
 
     private Long userId;
-
     private String nickname;
-
     private String imageUrl;
-
     private float degree;
-
     private List<Review> reviews;
 
-    private EmployerResponse(Long userId, String nickname, String imageUrl, float degree, List<Review> reviews) {
-        this.userId = userId;
-        this.nickname = nickname;
-        this.imageUrl = imageUrl;
-        this.degree = degree;
-        this.reviews = reviews;
-    }
 
     public static EmployerResponse of(User user, List<Review> reviews) {
         return EmployerResponse.builder()

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/dto/response/EmployerResponse.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/dto/response/EmployerResponse.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 @Getter
 @Builder
-@AllArgsConstructor
 public class EmployerResponse {
 
     private Long userId;
@@ -18,7 +17,6 @@ public class EmployerResponse {
     private String imageUrl;
     private float degree;
     private List<Review> reviews;
-
 
     public static EmployerResponse of(User user, List<Review> reviews) {
         return EmployerResponse.builder()

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/dto/response/EmployerResponse.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/employer/dto/response/EmployerResponse.java
@@ -2,19 +2,16 @@ package cds.carrot.org.carrotServer.controller.employer.dto.response;
 
 import cds.carrot.org.carrotServer.domain.employer.Review;
 import cds.carrot.org.carrotServer.domain.employer.User;
-import cds.carrot.org.carrotServer.service.employer.EmployerServiceImpl;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 @Getter
 @Builder
 @NoArgsConstructor
-public class EmployerResponseDto {
+public class EmployerResponse {
 
     private Long userId;
 
@@ -26,7 +23,7 @@ public class EmployerResponseDto {
 
     private List<Review> reviews;
 
-    private EmployerResponseDto(Long userId, String nickname, String imageUrl, float degree, List<Review> reviews) {
+    private EmployerResponse(Long userId, String nickname, String imageUrl, float degree, List<Review> reviews) {
         this.userId = userId;
         this.nickname = nickname;
         this.imageUrl = imageUrl;
@@ -34,8 +31,8 @@ public class EmployerResponseDto {
         this.reviews = reviews;
     }
 
-    public static EmployerResponseDto of(User user, List<Review> reviews) {
-        return EmployerResponseDto.builder()
+    public static EmployerResponse of(User user, List<Review> reviews) {
+        return EmployerResponse.builder()
                 .userId(user.getUserId())
                 .nickname(user.getNickname())
                 .imageUrl(user.getImageUrl())

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/post/PostController.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/post/PostController.java
@@ -13,6 +13,8 @@ import cds.carrot.org.carrotServer.service.employer.EmployerService;
 import cds.carrot.org.carrotServer.service.post.PostService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
@@ -31,8 +33,10 @@ public class PostController {
     private static final String AUTHORIZATION = "Authorization";
 
     @GetMapping("/list")
-    public JsonResponse getPostList(@RequestParam int size) {
-        if (size < 0) {
+    public JsonResponse getPostList(@RequestParam(required = false) Integer size) {
+        if (ObjectUtils.isEmpty(size)) {
+            throw new BadRequestException(ErrorType.VALIDATION_REQUEST_MISSING_EXCEPTION);
+        } else if (size < 0) {
             throw new BadRequestException(ErrorType.REQUEST_SIZE_EXCEPTION);
         }
         List<Post> posts = postService.getAll();
@@ -47,8 +51,10 @@ public class PostController {
     }
 
     @GetMapping("/recommend")
-    public JsonResponse getRecommendPostList(@RequestParam int size, HttpServletRequest request) {
-        if (size < 0) {
+    public JsonResponse getRecommendPostList(@RequestParam(required = false) Integer size, HttpServletRequest request) {
+        if (ObjectUtils.isEmpty(size)) {
+            throw new BadRequestException(ErrorType.VALIDATION_REQUEST_MISSING_EXCEPTION);
+        } else if (size < 0) {
             throw new BadRequestException(ErrorType.REQUEST_SIZE_EXCEPTION);
         }
         User findUser = employerService.getById(Long.parseLong(request.getHeader(AUTHORIZATION)));

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/post/dto/response/RecommendPostResponse.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/post/dto/response/RecommendPostResponse.java
@@ -8,12 +8,14 @@ import lombok.Getter;
 @Builder
 public class RecommendPostResponse {
 
+    Long postId;
     String title;
     String image;
     int monthlyWage;
 
     public static RecommendPostResponse of (Post post) {
         return RecommendPostResponse.builder()
+                .postId(post.getPostId())
                 .title(post.getTitle())
                 .image(post.getImageUrl())
                 .monthlyWage(post.getMonthlyWage())

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/user/UserController.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/user/UserController.java
@@ -11,15 +11,15 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.Valid;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
 public class UserController {
 
-    private final EmployerService employerService;
-
     @PostMapping("/profile")
-    public JsonResponse postUserProfile(@RequestBody CreateUserProfileRequest request) {
+    public JsonResponse postUserProfile(@Valid @RequestBody CreateUserProfileRequest request) {
         CreateUserProfileResponse response = CreateUserProfileResponse.of(request);
         return JsonResponse.success(SuccessType.CREATE_PROFILE_SUCCESS, response);
     }

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/user/UserController.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/user/UserController.java
@@ -21,6 +21,6 @@ public class UserController {
     @PostMapping("/profile")
     public JsonResponse postUserProfile(@RequestBody CreateUserProfileRequest request) {
         CreateUserProfileResponse response = CreateUserProfileResponse.of(request);
-        return JsonResponse.success(SuccessType.SIGNUP_SUCCESS, response);
+        return JsonResponse.success(SuccessType.CREATE_PROFILE_SUCCESS, response);
     }
 }

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/user/dto/request/CreateUserProfileRequest.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/controller/user/dto/request/CreateUserProfileRequest.java
@@ -5,13 +5,22 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateUserProfileRequest {
 
     private String name;
+
+    @NotNull(message = "'phoneNumber'은 필수값입니다.")
     private String phoneNumber;
-    private int gender;
-    private int birthYear;
+
+    @NotNull(message = "'gender'는 필수값입니다.")
+    private Integer gender;
+
+    @NotNull(message = "'birthYear'은 필수값입니다.")
+    private Integer birthYear;
+
     private String introduction;
 }

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/domain/post/Post.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/domain/post/Post.java
@@ -12,6 +12,8 @@ import java.util.List;
 @AllArgsConstructor
 public class Post {
 
+    private Long postId;
+
     private String company;
 
     private String title;

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/exception/BadRequestException.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/exception/BadRequestException.java
@@ -4,7 +4,7 @@ import cds.carrot.org.carrotServer.common.dto.ErrorType;
 
 public class BadRequestException extends ApiException {
 
-    public BadRequestException(ErrorType error, String message) {
-        super(error, message);
+    public BadRequestException(ErrorType error) {
+        super(error, error.getMessage());
     }
 }

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/exception/NotFoundException.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/exception/NotFoundException.java
@@ -4,7 +4,7 @@ import cds.carrot.org.carrotServer.common.dto.ErrorType;
 
 public class NotFoundException extends ApiException {
 
-    public NotFoundException(ErrorType error, String message) {
-        super(error, message);
+    public NotFoundException(ErrorType error) {
+        super(error, error.getMessage());
     }
 }

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/employer/EmployerService.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/employer/EmployerService.java
@@ -1,8 +1,13 @@
 package cds.carrot.org.carrotServer.service.employer;
 
-import cds.carrot.org.carrotServer.controller.employer.dto.response.EmployerResponse;
+import cds.carrot.org.carrotServer.domain.employer.Review;
+import cds.carrot.org.carrotServer.domain.employer.User;
+
+import java.util.List;
 
 public interface EmployerService {
 
-    EmployerResponse getUserWithReviews(Long userId, int size);
+    List<Review> getByUserId(Long userId);
+
+    User getById(Long userId);
 }

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/employer/EmployerService.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/employer/EmployerService.java
@@ -1,8 +1,8 @@
 package cds.carrot.org.carrotServer.service.employer;
 
-import cds.carrot.org.carrotServer.controller.employer.dto.response.EmployerResponseDto;
+import cds.carrot.org.carrotServer.controller.employer.dto.response.EmployerResponse;
 
 public interface EmployerService {
 
-    EmployerResponseDto getUserWithReviews(Long userId, int size);
+    EmployerResponse getUserWithReviews(Long userId, int size);
 }

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/employer/EmployerServiceImpl.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/employer/EmployerServiceImpl.java
@@ -1,10 +1,9 @@
 package cds.carrot.org.carrotServer.service.employer;
 
 import cds.carrot.org.carrotServer.common.dto.ErrorType;
-import cds.carrot.org.carrotServer.controller.employer.dto.response.EmployerResponseDto;
+import cds.carrot.org.carrotServer.controller.employer.dto.response.EmployerResponse;
 import cds.carrot.org.carrotServer.domain.employer.Review;
 import cds.carrot.org.carrotServer.domain.employer.User;
-import cds.carrot.org.carrotServer.exception.BadRequestException;
 import cds.carrot.org.carrotServer.exception.NotFoundException;
 import cds.carrot.org.carrotServer.infrastructure.review.ReviewEntity;
 import cds.carrot.org.carrotServer.infrastructure.review.ReviewRepository;
@@ -12,7 +11,6 @@ import cds.carrot.org.carrotServer.infrastructure.user.UserEntity;
 import cds.carrot.org.carrotServer.infrastructure.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,8 +23,7 @@ public class EmployerServiceImpl implements EmployerService {
     private final ReviewRepository reviewRepository;
 
     @Override
-    @Transactional
-    public EmployerResponseDto getUserWithReviews(Long userId, int size) {
+    public EmployerResponse getUserWithReviews(Long userId, int size) {
         List<ReviewEntity> reviewEntities = reviewRepository.findByUserId(userId);
 
         UserEntity userEntity = userRepository.findById(userId)
@@ -38,7 +35,7 @@ public class EmployerServiceImpl implements EmployerService {
 
         User user = fromUserEntityToUserMapper(userEntity);
 
-        return EmployerResponseDto.of(user, reviews);
+        return EmployerResponse.of(user, reviews);
     }
 
     private List<Review> getLimitedReviews(List<ReviewEntity> reviewEntityList, int maxSize) {

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/employer/EmployerServiceImpl.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/employer/EmployerServiceImpl.java
@@ -33,7 +33,7 @@ public class EmployerServiceImpl implements EmployerService {
     @Override
     public User getById(Long userId) {
         UserEntity userEntity = userRepository.findById(userId)
-                .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_USER_EXCEPTION, ErrorType.NOT_FOUND_USER_EXCEPTION.getMessage()));
+                .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_USER_EXCEPTION));
         return fromUserEntityToUserMapper(userEntity);
     }
 

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/employer/EmployerServiceImpl.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/employer/EmployerServiceImpl.java
@@ -1,7 +1,6 @@
 package cds.carrot.org.carrotServer.service.employer;
 
 import cds.carrot.org.carrotServer.common.dto.ErrorType;
-import cds.carrot.org.carrotServer.controller.employer.dto.response.EmployerResponse;
 import cds.carrot.org.carrotServer.domain.employer.Review;
 import cds.carrot.org.carrotServer.domain.employer.User;
 import cds.carrot.org.carrotServer.exception.NotFoundException;
@@ -23,27 +22,21 @@ public class EmployerServiceImpl implements EmployerService {
     private final ReviewRepository reviewRepository;
 
     @Override
-    public EmployerResponse getUserWithReviews(Long userId, int size) {
+    public List<Review> getByUserId(Long userId) {
         List<ReviewEntity> reviewEntities = reviewRepository.findByUserId(userId);
-
-        UserEntity userEntity = userRepository.findById(userId)
-                .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_USER_EXCEPTION, ErrorType.NOT_FOUND_USER_EXCEPTION.getMessage()));
-
-        int maxSize = Math.min(size, reviewEntities.size());
-
-        List<Review> reviews = getLimitedReviews(reviewEntities, maxSize);
-
-        User user = fromUserEntityToUserMapper(userEntity);
-
-        return EmployerResponse.of(user, reviews);
-    }
-
-    private List<Review> getLimitedReviews(List<ReviewEntity> reviewEntityList, int maxSize) {
-        return reviewEntityList.stream()
-                .limit(maxSize)
+        return reviewEntities
+                .stream()
                 .map(this::fromReviewEntityToReviewMapper)
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public User getById(Long userId) {
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_USER_EXCEPTION, ErrorType.NOT_FOUND_USER_EXCEPTION.getMessage()));
+        return fromUserEntityToUserMapper(userEntity);
+    }
+
 
     private User fromUserEntityToUserMapper(UserEntity userEntity) {
         return User.builder()

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/post/PostServiceImpl.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/post/PostServiceImpl.java
@@ -31,7 +31,7 @@ public class PostServiceImpl implements PostService {
     @Override
     public Post getById(Long postId) {
         PostEntity postEntity = postRepository.findById(postId)
-                .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_POST_EXCEPTION, ErrorType.NOT_FOUND_POST_EXCEPTION.getMessage()));
+                .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_POST_EXCEPTION));
         return fromPostEntityToPostMapper(postEntity);
     }
 

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/post/PostServiceImpl.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/post/PostServiceImpl.java
@@ -35,6 +35,7 @@ public class PostServiceImpl implements PostService {
 
     private Post fromPostEntityToPostMapper(PostEntity postEntity) {
         return Post.builder()
+                .postId(postEntity.getId())
                 .company(postEntity.getCompany())
                 .title(postEntity.getTitle())
                 .content(postEntity.getContent())

--- a/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/post/PostServiceImpl.java
+++ b/carrotServer/src/main/java/cds/carrot/org/carrotServer/service/post/PostServiceImpl.java
@@ -1,7 +1,9 @@
 package cds.carrot.org.carrotServer.service.post;
 
+import cds.carrot.org.carrotServer.common.dto.ErrorType;
 import cds.carrot.org.carrotServer.domain.post.Category;
 import cds.carrot.org.carrotServer.domain.post.Post;
+import cds.carrot.org.carrotServer.exception.NotFoundException;
 import cds.carrot.org.carrotServer.infrastructure.category.CategoryEntity;
 import cds.carrot.org.carrotServer.infrastructure.post.PostEntity;
 import cds.carrot.org.carrotServer.infrastructure.post.PostRepository;
@@ -29,7 +31,7 @@ public class PostServiceImpl implements PostService {
     @Override
     public Post getById(Long postId) {
         PostEntity postEntity = postRepository.findById(postId)
-                .orElseThrow(() -> new RuntimeException("id에 해당하는 글이 없습니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_POST_EXCEPTION, ErrorType.NOT_FOUND_POST_EXCEPTION.getMessage()));
         return fromPostEntityToPostMapper(postEntity);
     }
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #20 
- Closes #19 

## 🔑 Key Changes

1. string 사용한 것들 상수 사용해줬습니다!
2. `/recommend`의  post에 postId 추가했습니다~ api 명세서에도 반영했어요
3. size가 음수이거나 누락된 경우들 400 처리했습니다 (recommend, list)
    -> size가 누락되면 500으로 넘어가더라구요.. 그래서 `required=false`로 바꿨습니다 역시 서린이의 선견지명
4. api 명세서에 맞게 성공, 실패 메세지 수정했습니다
5. request 파라미터 누락시 핸들러 넣어줬습니다
6. request 헤더에 Authorization 체크하는 Interceptor 구현했습니다! -> 패키지 어디다 넣어야할지 몰라서 일단 common에 넣었오..ㅠ
7. EmployerService단에서 ResponseDto를 요리하는 게 맞나 싶어서 서린이처럼 구분해놨습니다 더 깔끔한 것 같아요 최고!!
8. `/profile` response에 NotNull처리 해줬습니다!

## 📢 To Reviewers
- 이거 .. 반영하면 배포를 다시 해야 하나요 ?! ㅠ
- #19 이슈 팠으면서 .. 생각 없이 #20 에서 구현해버렸네요
